### PR TITLE
Add memory tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ tests/%.xml: tests/%.test $(MAXMIND_DB)
 TEST_DEPS := tests/rb_netflow_test.o tests/rb_json_test.o
 tests/0023-testPrintbuf.test: TEST_DEPS =
 tests/%.test: CPPFLAGS := -I. $(CPPFLAGS)
+MALLOC_FUNCTIONS := $(strip malloc calloc strdup realloc)
+WRAP_ALLOC_FUNCTIONS := $(foreach fn, $(MALLOC_FUNCTIONS)\
+	,-Wl,-u,$(fn) -Wl,-wrap,$(fn))
 tests/%.test: tests/%.o tests/%.objdeps $(TEST_DEPS) $(OBJS)
 	$(CC) $(CPPFLAGS) $(LDFLAGS) $< $(shell cat $(@:.test=.objdeps)) $(TEST_DEPS) -o $@ $(LIBS) -lcmocka
 

--- a/tests/0042-testFlowV9_mem.c
+++ b/tests/0042-testFlowV9_mem.c
@@ -1,0 +1,155 @@
+#include "nprobe.h"
+
+#include "rb_netflow_test.h"
+#include "rb_mem_wraps.h"
+
+#include <librd/rd.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+/* WFII-startwithtemplate pcap */
+
+/// @todo template+flow in the same message
+/// @todo Extract in its own header, (the current problem is end buffer size?)
+struct TestV9Template{
+	V9FlowHeader flowHeader;
+	V9TemplateHeader flowSetHeader;
+	V9TemplateDef templateHeader;
+	V9FlowSet templateSet[10];
+};
+
+struct TestV9Flow{
+	V9FlowHeader flowHeader;
+	V9TemplateHeader flowSetHeader;
+	const uint8_t buffer[72];
+};
+
+static const struct TestV9Template v9Template = {
+	.flowHeader = {
+		/*uint16_t*/ .version = 0x0900,           /* Current version=9*/
+		/*uint16_t*/ .count = 0x0100,           /* The number of records in PDU. */
+		/*uint32_t*/ .sysUptime = 0x00003039,     /* Current time in msecs since router booted */
+		/*uint32_t*/ .unix_secs = 0xe2336552,     /* Current seconds since 0000 UTC 1970 */
+		/*uint32_t*/ .flow_sequence = 0x38040000, /* Sequence number of total flows seen */
+		/*uint32_t*/ .sourceId = 0x01000000,      /* Source id */
+	},
+
+	.flowSetHeader = {
+		/*uint16_t*/ .templateFlowset = 0x0000,
+		/*uint16_t*/ .flowsetLen = 0x3000,
+	},
+
+	.templateHeader = {
+		/*uint16_t*/ .templateId = 0x0301, /*259*/
+		/*uint16_t*/ .fieldCount = 0x0a00,
+	},
+
+	.templateSet = { /* all uint16_t*/
+		[0] = {.templateId = 0x6d01 /* 365: STA_MAC_ADDRESS  */, .flowsetLen = 0x0600},
+		[1] = {.templateId = 0x6e01 /* 366: STA_IPV4_ADDRESS */, .flowsetLen = 0x0400},
+		[2] = {.templateId = 0x5f00 /*  95: APPLICATION_ID */,   .flowsetLen = 0x0400},
+		[3] = {.templateId = 0x9300 /* 147: WLAN_SSID */, .flowsetLen = 0x2100},
+		[4] = {.templateId = 0x3d00 /*  61: DIRECTION */, .flowsetLen = 0x0100},
+		[5] = {.templateId = 0x0100 /*   1: BYTES */, .flowsetLen = 0x0800},
+		[6] = {.templateId = 0x0200 /*   2: PKTS */, .flowsetLen = 0x0800},
+		[7] = {.templateId = 0x6200 /*  98: Not processed */, .flowsetLen = 0x0100},
+		[8] = {.templateId = 0xc300 /* 195: Not processed */, .flowsetLen = 0x0100},
+		[9] = {.templateId = 0x616f /* 367: WAP_MAC_ADDRESS */, .flowsetLen = 0x0600},
+	}
+};
+
+static const struct TestV9Flow v9Flow = {
+	.flowHeader = {
+		/*uint16_t*/ .version = 0x0900,           /* Current version=9*/
+		/*uint16_t*/ .count = 0x0100,           /* The number of records in PDU. */
+		/*uint32_t*/ .sysUptime = 0x00003039,     /* Current time in msecs since router booted */
+		/*uint32_t*/ .unix_secs = 0x98346552,     /* Current seconds since 0000 UTC 1970 */
+		/*uint32_t*/ .flow_sequence = 0x76040000, /* Sequence number of total flows seen */
+		/*uint32_t*/ .sourceId = 0x01000000,      /* Source id */
+	},
+
+	.flowSetHeader = {
+		/*uint16_t*/ .templateFlowset = 0x0301,
+		/*uint16_t*/ .flowsetLen = 0x4800,
+	},
+
+	.buffer = {
+		0xb8, 0x17, 0xc2, 0x28, 0xb0, 0xc7, /* STA_MAC_ADDRESS: b8:14:c2:28:b0:c7 */
+		0x0a, 0x0d, 0x5e, 0xdf,             /* STA_IPV4_ADDRESS: 10.13.94.223 */
+		0x0d, 0x00, 0x01, 0xc5,             /* App Id: 13:453 */
+		0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x2d, /* WLAN_SSID: "local-wifi" */
+		0x77, 0x69, 0x66, 0x69, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00,
+		0x00,                               /* Direction: Ingress */
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1d, 0xb3, /* Octetos */
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x07, /* Paquetes */
+		0x00, 0x00,                         /* Not used */
+		0x58, 0xbf, 0xea, 0x01, 0x5b, 0x40, /* WAP_MAC_ADDRESS */
+	}
+};
+
+static const struct checkdata_value checkdata_values[] = {
+	{.key = "type", .value="netflowv9",},
+	{.key = "client_mac", .value="b8:17:c2:28:b0:c7",},
+	{.key = "src", .value="10.13.94.223",},
+	{.key = "application_id", .value="13:453",},
+	{.key = "wireless_id", .value="local-wifi",},
+	{.key = "direction", .value="ingress",},
+	{.key = "sensor_ip", .value="4.3.2.1",},
+	{.key = "bytes", .value="7603",},
+	{.key = "packets", .value="263"},
+};
+
+static int prepare_test_nf9(void **state) {
+	static const struct checkdata checkdata = {
+		.size = 1, .checks = checkdata_values
+	};
+
+#define TEST(config_path, mrecord, mrecord_size, mcheckdata, mcheckdata_sz) {  \
+		.config_json_path = config_path,                               \
+		.host_list_path = NULL,                                        \
+		.netflow_src_ip = 0x04030201,                                  \
+		.netflow_dst_port = 2055,                                      \
+		.record = mrecord,                                             \
+		.record_size = mrecord_size,                                   \
+		.checkdata = mcheckdata,                                       \
+		.checkdata_size = mcheckdata_sz                                \
+	}
+
+#define TEST_TEMPLATE_FLOW(config_path, template, template_size,               \
+				flow, flow_size, mcheckdata, mcheckdata_sz)    \
+	[0] = TEST(config_path, template, template_size, NULL, 0),             \
+	[1] = TEST(NULL, flow, flow_size, mcheckdata, mcheckdata_sz)
+
+	struct test_params test_params[] = {
+		TEST_TEMPLATE_FLOW(
+			"./tests/0000-testFlowV5.json",
+			(uint8_t *)&v9Template, sizeof(v9Template),
+			(uint8_t *)&v9Flow, sizeof(v9Flow),
+			&checkdata, 1),
+	};
+
+	*state = prepare_tests(test_params, RD_ARRAYSIZE(test_params));
+	return *state == NULL;
+}
+
+static void mem_test(void **state) {
+  size_t i = 1;
+  do {
+    mem_wrap_fail_in = i++;
+    testFlow(state);
+  } while (0 == mem_wrap_fail_in);
+  mem_wrap_fail_in = 0;
+}
+
+int main() {
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test_setup(mem_test, prepare_test_nf9),
+  };
+
+  return cmocka_run_group_tests(tests, nf_test_setup, NULL);
+}

--- a/tests/0042-testFlowV9_mem.objdeps
+++ b/tests/0042-testFlowV9_mem.objdeps
@@ -1,0 +1,1 @@
+rb_mac.o rb_listener.o export.o globals.o printbuf.o engine.o template.o util.o rb_sensor.o NumNameAssocTree.o

--- a/tests/0043-testFlowV10_mem.c
+++ b/tests/0043-testFlowV10_mem.c
@@ -1,0 +1,177 @@
+#include "nprobe.h"
+#include "rb_mem_wraps.h"
+#include "rb_netflow_test.h"
+
+#include <librd/rd.h>
+
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+/// @todo template+flow in the same message
+struct TestV10Template {
+  IPFIXFlowHeader flowHeader;
+  IPFIXSet flowSetHeader;
+  V9TemplateDef templateHeader; /* It's the same */
+  const uint8_t templateBuffer[92];
+};
+
+struct TestV10Flow {
+  IPFIXFlowHeader flowHeader;
+  IPFIXSet flowSetHeader;
+  const uint8_t buffer1[77];
+} __attribute__((packed));
+
+static const struct TestV10Template v10Template = {
+    .flowHeader =
+        {
+            /*uint16_t*/.version = 0x0a00, /* Current version=9*/
+            /*uint16_t*/.len = 0x7400,     /* The number of records in PDU. */
+            /*uint32_t*/.sysUptime =
+                0xdd5d6952, /* Current time in msecs since router booted */
+            /*uint32_t*/.flow_sequence =
+                0x38040000, /* Sequence number of total flows seen */
+            /*uint32_t*/.observationDomainId = 0x00010000, /* Source id */
+        },
+
+    .flowSetHeader =
+        {
+            /*uint16_t*/.set_id = 0x0200,
+            /*uint16_t*/.set_len = 0x6400,
+        },
+
+    .templateHeader =
+        {
+            /*uint16_t*/.templateId = 0x0d01, /*269*/
+            /*uint16_t*/.fieldCount = 0x1300,
+        },
+
+    .templateBuffer =
+        {
+            0x00, 0x08, 0x00, 0x04, /* SRC ADDR */
+            0x00, 0x0c, 0x00, 0x04, /* DST ADDR */
+            0x00, 0x3c, 0x00, 0x01, /* IP VERSION */
+            0x00, 0x04, 0x00, 0x01, /* PROTO */
+            0x00, 0x07, 0x00, 0x02, /* SRC PORT */
+            0x00, 0x0b, 0x00, 0x02, /* DST PORT */
+            0x00, 0x88, 0x00, 0x01, /* flowEndreason */
+            0x00, 0xef, 0x00, 0x01, /* biflowDirection */
+            0x00, 0x30, 0x00, 0x01, /* FLOW_SAMPLER_ID */
+            0x01, 0x18, 0x00, 0x08, /* TRANSACTION_ID */
+            0x00, 0x5f, 0x00, 0x04, /* APPLICATION ID*/
+            0xaf, 0xcb, 0xff, 0xff, 0x00, 0x00, 0x00, 0x09, /* CISCO_URL, variable length */
+            0xaf, 0xcb, 0xff, 0xff,
+            0x00, 0x00, 0x00, 0x09, /* CISCO_URL, variable length */
+            0xaf, 0xcb, 0xff, 0xff,
+            0x00, 0x00, 0x00, 0x09, /* CISCO_URL, variable length */
+            0xaf, 0xcb, 0xff, 0xff,
+            0x00, 0x00, 0x00, 0x09, /* CISCO_URL, variable length */
+            0x00, 0x01, 0x00, 0x08, /* BYTES: */
+            0x00, 0x02, 0x00, 0x04, /* PKTS*/
+            0x00, 0x16, 0x00, 0x04, /* FIRST_SWITCHED */
+            0x00, 0x15, 0x00, 0x04, /* LAST_SWITCHED*/
+        }};
+
+static const struct TestV10Flow v10Flow = {
+    .flowHeader =
+        {
+            /*uint16_t*/.version = 0x0a00, /* Current version=9*/
+            /*uint16_t*/.len = 0x6100,     /* The number of records in PDU. */
+            /*uint32_t*/.sysUptime =
+                0xdd5d6952, /* Current time in msecs since router booted */
+            /*uint32_t*/.flow_sequence =
+                0x38040000, /* Sequence number of total flows seen */
+            /*uint32_t*/.observationDomainId = 0x00010000, /* Source id */
+        },
+
+    .flowSetHeader =
+        {
+            /*uint16_t*/.set_id = 0x0d01,
+            /*uint16_t*/.set_len = 0x5100,
+        },
+
+    .buffer1 =
+        {
+            0x0a, 0x0d, 0x7a, 0x2c, /* SRC ADDR 10.13.122.44 */
+            0x42, 0xdc, 0x98, 0x13, /* DST ADDR 66.220.152.19*/
+            0x04,                   /* IP VERSION: 4 */
+            0x06,                   /* PROTO: 6 */
+            0xd5, 0xb9,             /* SRC PORT: 54713 */
+            0x01, 0xbb,             /* DST PORT: 443 */
+            0x03,                   /* flowEndreason */
+            0x01,                   /* biflowDirection */
+            0x00,                   /* FLOW_SAMPLER_ID */
+            0x8f, 0x63, 0xf3, 0x40, 0x00, 0x01, 0x00, 0x00, /* TRANSACTION_ID */
+            0x0d, 0x00, 0x01, 0xc5, /* APPLICATION ID 13:453 */
+            0x06, 0x03, 0x00, 0x00, 0x50, 0x34, 0x01,       /* CISCO_URL */
+            0x06, 0x03, 0x00, 0x00, 0x50, 0x34, 0x02,       /* CISCO_URL */
+            0x06, 0x03, 0x00, 0x00, 0x50, 0x34, 0x03,       /* CISCO_URL */
+            0x06, 0x03, 0x00, 0x00, 0x50, 0x34, 0x04,       /* CISCO_URL */
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0a, 0xb8, /* BYTES: 2744 */
+            0x00, 0x00, 0x00, 0x1f,                         /* PKTS: 31*/
+            0x0f, 0xed, 0x0a, 0xc0, /* FIRST_SWITCHED:  */
+            0x0f, 0xee, 0x18, 0x00, /* LAST_SWITCHED: */
+        },
+};
+
+static const struct checkdata_value checkdata_values1[] = {
+    {.key = "type", .value = "netflowv10"},
+    {.key = "src", .value = "10.13.122.44"},
+    {.key = "dst", .value = "66.220.152.19"},
+    {.key = "ip_protocol_version", .value = "4"},
+    {.key = "l4_proto", .value = "6"},
+    {.key = "src_port", .value = "54713"},
+    {.key = "dst_port", .value = "443"},
+    {.key = "flow_end_reason", .value = "end of flow"},
+    {.key = "biflow_direction", .value = "initiator"},
+    {.key = "application_id", .value = NULL},
+
+    {.key = "sensor_ip", .value = "4.3.2.1"},
+    {.key = "sensor_name", .value = "FlowTest"},
+    {.key = "bytes", .value = "2744"},
+    {.key = "pkts", .value = "31"},
+    {.key = "first_switched", .value = "1382636953"},
+    {.key = "timestamp", .value = "1382637021"},
+};
+
+static int prepare_test_nf10(void **state) {
+  static const struct checkdata sl1_checkdata = {
+      .checks = checkdata_values1, .size = RD_ARRAYSIZE(checkdata_values1)};
+
+#define TEST(config_path, mhosts_db_path, mrecord, mrecord_size, checks,       \
+             checks_size)                                                      \
+  {                                                                            \
+    .config_json_path = config_path, .host_list_path = mhosts_db_path,         \
+    .netflow_src_ip = 0x04030201, .netflow_dst_port = 2055, .record = mrecord, \
+    .record_size = mrecord_size, .checkdata = checks,                          \
+    .checkdata_size = checks_size                                              \
+  }
+
+  struct test_params test_params[] = {
+          [0] = TEST("./tests/0000-testFlowV5.json", "./tests/0011-data/",
+                     (uint8_t *)&v10Template, sizeof(v10Template), NULL, 0),
+
+          [1] = TEST(NULL, NULL, (uint8_t *)&v10Flow, sizeof(v10Flow),
+                     &sl1_checkdata, 1),
+  };
+
+  *state = prepare_tests(test_params, RD_ARRAYSIZE(test_params));
+  return *state == NULL;
+}
+
+static void mem_test(void **state) {
+  size_t i = 1;
+  do {
+    mem_wrap_fail_in = i++;
+    testFlow(state);
+  } while (0 == mem_wrap_fail_in);
+  mem_wrap_fail_in = 0;
+}
+
+int main() {
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test_setup(mem_test, prepare_test_nf10),
+  };
+
+  return cmocka_run_group_tests(tests, nf_test_setup, NULL);
+}

--- a/tests/0043-testFlowV10_mem.objdeps
+++ b/tests/0043-testFlowV10_mem.objdeps
@@ -1,0 +1,1 @@
+rb_mac.o rb_listener.o export.o globals.o printbuf.o engine.o template.o util.o rb_sensor.o NumNameAssocTree.o


### PR DESCRIPTION
Use a wrapper for functions like `malloc` or `calloc` that fails under some circumstances.
- [x] Wrap `malloc`s and `calloc`s on tests to improve the program robustness
- [x] `0041-testFlowV5_mem`
- [x] `0042-testFlowV9_mem`
- [x] `0043-testFlowV10_mem`

NOTE: Memory checks could be done before function call. 

---

Closes #5 
