### PR TITLE
Fix coverage compute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ services:
   - docker
 
 install:
-  - sudo apt-get install -y docker-engine
   - pip install --user cpp-coveralls
 
 script:
@@ -30,8 +29,6 @@ after_success:
   - docker run -v $(pwd):/app redborder/build-dockerfiles:f2k make clean
   - docker run -v $(pwd):/app redborder/build-dockerfiles:f2k ./configure --enable-coverage
   - docker run -v $(pwd):/app -e CFLAGS=-w --link kafka --net test redborder/build-dockerfiles:f2k make coverage
-  - docker run -v $(pwd):/app redborder/build-dockerfiles:f2k lcov --remove tests/coverage.info 'tests/*' '/usr/*' --output-file tests/coverage.info
-  - docker run -v $(pwd):/app redborder/build-dockerfiles:f2k lcov --list tests/coverage.info
   - coveralls --exclude /usr/lib --exclude tests --gcov-options '\-lp'
 
 before_deploy:

--- a/Makefile
+++ b/Makefile
@@ -136,14 +136,19 @@ COV_VALGRIND ?= valgrind
 COV_GCOV ?= gcov
 COV_LCOV ?= lcov
 
-coverage: check_coverage $(TESTS)
-	( for test in $(TESTS); do ./$$test; done )
-	$(COV_LCOV) --gcov-tool=$(COV_GCOV) -q \
-                --rc lcov_branch_coverage=1 --capture \
-                --directory ./ --output-file ${COVERAGE_INFO}
+coverage: check_coverage $(TESTS) checks
+	@$(COV_LCOV) --gcov-tool=$(COV_GCOV) -q \
+                --rc lcov_branch_coverage=1 \
+								--capture \
+                --directory ./ --output-file ${COVERAGE_INFO} >/dev/null 2>&1
+	@$(COV_LCOV) --remove coverage.info '/app/tests/*' 'include/*' \
+								--rc lcov_branch_coverage=1 \
+								--compat-libtool \
+								--output-file coverage.info >/dev/null 2>&1
+	@$(COV_LCOV) --list --rc lcov_branch_coverage=1 coverage.info
+
+coverage-html: coverage
 	genhtml --branch-coverage ${COVERAGE_INFO} --output-directory \
 				${COVERAGE_OUTPUT_DIRECTORY} > coverage.out
-	# ./display_coverage.sh
 
 -include $(DEPS)
-#

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/redBorder/f2k.svg?branch=master)](https://travis-ci.org/redBorder/f2k)
+[![Coverage Status](https://coveralls.io/repos/github/redBorder/f2k/badge.svg?branch=master)](https://coveralls.io/github/redBorder/f2k?branch=master)
 
 # Flow 2 Kafka (f2k)
 

--- a/configure.f2k
+++ b/configure.f2k
@@ -20,14 +20,15 @@ mkl_mkvar_append CPPFLAGS CPPFLAGS "-Wmissing-declarations"
 mkl_mkvar_append CPPFLAGS CPPFLAGS "-Wdisabled-optimization -Wshadow"
 mkl_mkvar_append CPPFLAGS CPPFLAGS "-Wcast-qual -Wunused -Wextra"
 
-mkl_toggle_option "Standard" WITH_LIBRDKAFKA        "--enable-librdkafka"        "librdkafka: For kafka export" "y"
-mkl_toggle_option "Standard" WITH_RBMAC_VENDOR      "--enable-rbmacvendor"       "RedBorder MACs vendor library" "y"
-mkl_toggle_option "Standard" WITH_GEOIP             "--enable-geoip"             "MaxMind (r) GeoIP library" "y"
-mkl_toggle_option "Standard" WITH_SFLOW             "--enable-sflow"             "S-FLOW Support" "n"
-mkl_toggle_option "Standard" WITH_ZOOKEEPER         "--enable-zookeeper"         "Apache Zookeeper support" "y"
-mkl_toggle_option "Standard" WITH_UDNS              "--enable-udns"              "Michael Tokarev reverse-DNS support" "y"
-mkl_toggle_option "Feature"  WITH_INTEGRATION_TESTS "--enable-integration-tests" "Run integration tests" "n"
+mkl_toggle_option "Standard" WITH_LIBRDKAFKA        "--enable-librdkafka"          "librdkafka: For kafka export" "y"
+mkl_toggle_option "Standard" WITH_RBMAC_VENDOR      "--enable-rbmacvendor"         "RedBorder MACs vendor library" "y"
+mkl_toggle_option "Standard" WITH_GEOIP             "--enable-geoip"               "MaxMind (r) GeoIP library" "y"
+mkl_toggle_option "Standard" WITH_SFLOW             "--enable-sflow"               "S-FLOW Support" "n"
+mkl_toggle_option "Standard" WITH_ZOOKEEPER         "--enable-zookeeper"           "Apache Zookeeper support" "y"
+mkl_toggle_option "Standard" WITH_UDNS              "--enable-udns"                "Michael Tokarev reverse-DNS support" "y"
+mkl_toggle_option "Feature"  WITH_INTEGRATION_TESTS "--enable-integration-tests"   "Run integration tests" "n"
 mkl_toggle_option "Feature"  WITH_PRINT_BOUND_CHECKS "--enable-export-bounds-chks" "Checks bound in export functions (SLOW!)" "n"
+mkl_toggle_option "Feature"  WITH_COVERAGE           "--enable-coverage"           "Coverage build" "n"
 
 function checks_librdkafka {
     # Check that librdkafka is available, and allow to link it statically.
@@ -131,4 +132,13 @@ function checks {
     mkl_lib_check pf_ring HAVE_PF_RING disable CC "-lpfring" \
         "#include <pfring.h>
          void *f();void *f(){return pfring_open;}"
+
+    if [[ "x$WITHOUT_OPTIMIZATION" != "xy" || "x$WITH_COVERAGE" != "xy" ]]; then
+      mkl_mkvar_append CPPFLAGS CPPFLAGS "-DNDEBUG"
+    fi
+
+    if [[ "x$WITH_COVERAGE" != "xn" ]]; then
+      mkl_mkvar_append CPPFLAGS CPPFLAGS "--coverage"
+      mkl_mkvar_append LDFLAGS LDFLAGS "--coverage"
+    fi
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -108,7 +108,7 @@ for FILE in $*; do
     for i in $(seq 1 $MEM_ERRORS); do
       # Display error
       TEXT="$(valgrind_xml_error_text $MEM_XML $i)"
-      printf "\t\e[31m • %s\e[0m\n" "$TEXT"
+      printf "\t\e[33m • %s\e[0m\n" "$TEXT"
 
       # Count bytes lost due to this error
       BYTES="$(xml-printf '%s' $MEM_XML ://error[$i]/xwhat/leakedbytes 2>/dev/null)"
@@ -130,13 +130,13 @@ for FILE in $*; do
     for i in $(seq 1 $HELGRIND_ERRORS); do
       # Display helgrind error
       TEXT="$(valgrind_xml_error_text $HELGRIND_XML $i)"
-      printf "\t\e[31m • \e[1m[HELGRIND] \e[0;31m%s\e[0m\n" "$TEXT"
+      printf "\t\e[33m • \e[1m[HELGRIND] \e[0;33m%s\e[0m\n" "$TEXT"
     done
 
     for i in $(seq 1 $DRD_ERRORS); do
       # Display drd error
       TEXT="$(valgrind_xml_error_text $DRD_XML $i)"
-      printf "\t\e[31m • \e[1m[DRD] \e[0;31m%s\e[0m\n" "$TEXT"
+      printf "\t\e[33m • \e[1m[DRD] \e[0;33m%s\e[0m\n" "$TEXT"
     done
     printf "\t\e[1m---------------------------------------------------------------------------------------------\e[0m\n"
   fi


### PR DESCRIPTION
Code coverage computing and upload to coveralls is broken. This pr should fix it:

- [x] Add `--enable-coverage` flags to configure script.
- [x] `make coverage` filters the coverage from external code (previously done by Travis script).
- [x] New target `make coverage-html` to generate an html with details.
- [x] Tests display script now shows valgrind checks on yellow instead red.  

---

Fixes #27 